### PR TITLE
feat(rules): add a rule to check that graphQL mutation decorator and …

### DIFF
--- a/lib/rules/mutation-decorator-return-type-mismatch.ts
+++ b/lib/rules/mutation-decorator-return-type-mismatch.ts
@@ -1,0 +1,100 @@
+import {
+  AST_NODE_TYPES,
+  ESLintUtils,
+  TSESTree,
+} from "@typescript-eslint/utils";
+
+type MessageIds = "mutation-decorator-return-type-mismatch";
+
+type Options = [];
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://hokla.com/rule/${name}`
+);
+
+// Type: RuleModule<"uppercase", ...>
+export const rule = createRule<Options, MessageIds>({
+  name: "type-mismatch",
+  defaultOptions: [],
+  create(context) {
+    function isMethodDefinition(
+      node?: TSESTree.Node
+    ): node is TSESTree.MethodDefinition {
+      return node?.type === AST_NODE_TYPES.MethodDefinition;
+    }
+
+    function getMethodDefinitionFromDecorator(
+      node: TSESTree.Decorator
+    ): TSESTree.MethodDefinition | undefined {
+      const parent = node.parent;
+
+      if (!isMethodDefinition(parent)) {
+        return undefined;
+      }
+      return parent;
+    }
+
+    function getMethodReturnType(
+      node: TSESTree.MethodDefinition
+    ): TSESTree.TSTypeAnnotation["typeAnnotation"] | undefined {
+      return node?.value?.returnType?.typeAnnotation;
+    }
+
+    function getMutationDecoratorReturnType(
+      node: TSESTree.Decorator
+    ): TSESTree.BlockStatement | TSESTree.Expression | undefined {
+      if (node.expression.type !== AST_NODE_TYPES.CallExpression)
+        return undefined;
+
+      const callNode = node.expression;
+      const firstArgument = callNode.arguments[0];
+
+      if (firstArgument?.type !== AST_NODE_TYPES.ArrowFunctionExpression)
+        return undefined;
+
+      return firstArgument.body;
+    }
+
+    return {
+      ['MethodDefinition > Decorator[expression.callee.name="Mutation"]'](
+        node: TSESTree.Decorator
+      ) {
+        const methodDefinition = getMethodDefinitionFromDecorator(node);
+        if (methodDefinition === undefined) return;
+
+        const methodReturnType = getMethodReturnType(methodDefinition);
+        const methodReturnTypeText = context
+          .getSourceCode()
+          .getText(methodReturnType);
+
+        const mutationDecoratorReturnType =
+          getMutationDecoratorReturnType(node);
+        const mutationDecoratorReturnTypeText = context
+          .getSourceCode()
+          .getText(mutationDecoratorReturnType);
+
+        if (methodReturnTypeText !== mutationDecoratorReturnTypeText) {
+          context.report({
+            messageId: "mutation-decorator-return-type-mismatch",
+            node: node,
+          });
+        }
+      },
+    };
+  },
+  meta: {
+    docs: {
+      recommended: "error",
+      description:
+        "Parameter of Mutation Decorator should match the method's return type",
+    },
+    messages: {
+      "mutation-decorator-return-type-mismatch":
+        "Return type in Mutation Decorator's parameter does not match the mutation's return type",
+    },
+    type: "problem",
+    schema: [],
+  },
+});
+
+export default rule;

--- a/tests/mutation-decorator-type-mismatch.spec.ts
+++ b/tests/mutation-decorator-type-mismatch.spec.ts
@@ -1,0 +1,69 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { rule } from "../lib/rules/mutation-decorator-return-type-mismatch";
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: "@typescript-eslint/parser",
+});
+
+ruleTester.run("mutation-decorator-return-type-mismatch", rule, {
+  valid: [
+    `
+    class MyService {
+      @Mutation(() => GivenType)
+      async anyServiceMethod(
+        deletePortalUsersFields: DeletePortalUsersDto,
+      ): GivenType {
+        doAnything();
+        doAnythingElse();
+        return objectOfTypeGivenType;
+      }
+    }
+    `,
+    `
+    class MyService {
+      @Mutation(() => Promise<PortalUser[]>)
+      async deletePortalUsers(
+        deletePortalUsersFields: DeletePortalUsersDto,
+      ): Promise<PortalUser[]> {
+        return this.portalUserService.deletePortalUsers(
+          portalUser,
+          deletePortalUsersFields,
+        );
+      }
+    }
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+      class MyService {
+        @Mutation(() => GivenType1)
+        async anyServiceMethod(
+          deletePortalUsersFields: DeletePortalUsersDto,
+        ): GivenType2 {
+          doAnything();
+          doAnythingElse();
+          return objectOfTypeGivenType2; 
+        }
+      }
+      `,
+      errors: [{ messageId: "mutation-decorator-return-type-mismatch" }],
+    },
+    {
+      code: `
+      class MyService {
+        @Mutation(() => Promise<PortalUser[]>)
+        async deletePortalUsers(
+          deletePortalUsersFields: DeletePortalUsersDto,
+        ): Promise<number> {
+          return this.portalUserService.deletePortalUsers(
+            portalUser,
+            deletePortalUsersFields,
+          );
+        }
+      }
+    `,
+      errors: [{ messageId: "mutation-decorator-return-type-mismatch" }],
+    },
+  ],
+});


### PR DESCRIPTION
…method return type match

## 🔎 Description

> One sentence - explain the bad practice you want to kill with a new rule

---

## 🧪 Code samples :

Wrong code samples :

```

```

Good code samples :

```

```

---

## 📜 To do before asking for reviews

- [ ] This rule does not exist in standard eslint plugins
- [ ] I have added a test to prove my rule works
- [ ] The CI checks all passed

---

## 📣 When merging !

Please inform everyone to upgrade the hokla eslint plugin to benefit from your piece !
https://hokla.slack.com/archives/C02CZUN4QUW
Tell them to run `yarn upgrade @hokla/eslint-plugin-custom-rules` or `npm update @hokla/eslint-plugin-custom-rules`

---

## 🖼 Screenshots

[Screenshot to show the resulting warnings]
